### PR TITLE
Added UI selection for thermal elements in Rescue B map creation

### DIFF
--- a/scorebrd/static/js/mapgen-b.js
+++ b/scorebrd/static/js/mapgen-b.js
@@ -232,3 +232,7 @@ $(document).ready(function () {
     });*/
 });
 
+// checks a value lies within +- of target value
+function plusminus(val, comp, pad) {
+	return (val >= (comp - pad) && val <= (comp + pad));	
+}


### PR DESCRIPTION
Thermal elements can now be placed on any of the four walls when creating a design for Rescue B - e.g. click at the top of the cell to place an element on the top wall.
